### PR TITLE
Fix github.Error when it has no Response field

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -656,6 +656,9 @@ func CheckResponse(r *http.Response) error {
 	data, err := ioutil.ReadAll(r.Body)
 	if err == nil && data != nil {
 		json.Unmarshal(data, errorResponse)
+		if errorResponse.Response == nil {
+			errorResponse.Response = r
+		}
 	}
 	switch {
 	case r.StatusCode == http.StatusUnauthorized && strings.HasPrefix(r.Header.Get(headerOTP), "required"):

--- a/github/github.go
+++ b/github/github.go
@@ -515,6 +515,12 @@ type ErrorResponse struct {
 }
 
 func (r *ErrorResponse) Error() string {
+	if r.Response == nil {
+		return fmt.Sprintf("%v %+v", r.Message, r.Errors)
+	} else if r.Response.Request == nil {
+		return fmt.Sprintf("%d %v %+v", r.Response.StatusCode, r.Message, r.Errors)
+	}
+
 	return fmt.Sprintf("%v %v: %d %v %+v",
 		r.Response.Request.Method, sanitizeURL(r.Response.Request.URL),
 		r.Response.StatusCode, r.Message, r.Errors)
@@ -536,6 +542,14 @@ type RateLimitError struct {
 }
 
 func (r *RateLimitError) Error() string {
+	if r.Response == nil {
+		return fmt.Sprintf("%v %v",
+			r.Message, formatRateReset(r.Rate.Reset.Time.Sub(time.Now())))
+	} else if r.Response.Request == nil {
+		return fmt.Sprintf("%d %v %v",
+			r.Response.StatusCode, r.Message, formatRateReset(r.Rate.Reset.Time.Sub(time.Now())))
+	}
+
 	return fmt.Sprintf("%v %v: %d %v %v",
 		r.Response.Request.Method, sanitizeURL(r.Response.Request.URL),
 		r.Response.StatusCode, r.Message, formatRateReset(r.Rate.Reset.Time.Sub(time.Now())))
@@ -566,6 +580,12 @@ type AbuseRateLimitError struct {
 }
 
 func (r *AbuseRateLimitError) Error() string {
+	if r.Response == nil {
+		return fmt.Sprintf("%v", r.Message)
+	} else if r.Response.Request == nil {
+		return fmt.Sprintf("%d %v", r.Response.StatusCode, r.Message)
+	}
+
 	return fmt.Sprintf("%v %v: %d %v",
 		r.Response.Request.Method, sanitizeURL(r.Response.Request.URL),
 		r.Response.StatusCode, r.Message)


### PR DESCRIPTION
somehow related to https://github.com/google/go-github/issues/540

When the API response body has no `Response` field, the error generated by [`CheckResponse`](https://github.com/google/go-github/blob/56cb1dd99043eba2e21c91aa8417d3ba2329259a/github/github.go#L712) is "incomplete" and causes a `Panic` if calling [`Error()`](https://github.com/google/go-github/blob/56cb1dd99043eba2e21c91aa8417d3ba2329259a/github/github.go#L598) over it.
